### PR TITLE
Add CheXpert dataset and grayscale VAE option

### DIFF
--- a/main/configs/dataset/chexpert/test.yaml
+++ b/main/configs/dataset/chexpert/test.yaml
@@ -1,0 +1,73 @@
+# DDPM config used for DDPM training
+ddpm:
+  data:
+    root: ???
+    name: "chexpert"
+    image_size: 224
+    hflip: False
+    n_channels: 1
+    norm: True
+    ddpm_latent_path: ""
+
+  model:
+    dim : 128
+    attn_resolutions: "32,"
+    n_residual: 2
+    dim_mults: "1,2,2,2"
+    dropout: 0.1
+    n_heads: 8
+    beta1: 0.0001
+    beta2: 0.02
+    n_timesteps: 1000
+
+  evaluation:
+    chkpt_path: ???
+    save_path: ???
+    z_cond: False
+    z_dim: 1024
+    guidance_weight: 0.0
+    type: 'form1'
+    resample_strategy: "spaced"
+    skip_strategy: "uniform"
+    sample_method: "ddpm"
+    sample_from: "target"
+    seed: 0
+    device: "gpu:0"
+    n_samples: 50000
+    n_steps: 1000
+    workers: 2
+    batch_size: 8
+    save_vae: False
+    variance: "fixedlarge"
+    sample_prefix: ""
+    temp: 1.0
+    save_mode: image
+
+  interpolation:
+    n_steps: 10
+
+vae:
+  data:
+    root: ???
+    name: "chexpert"
+    image_size: 224
+    n_channels: 1
+
+  model:
+    z_dim: 1024
+    enc_block_config : "128x1,128d2,128t64,64x3,64d2,64t32,32x3,32d2,32t16,16x7,16d2,16t8,8x3,8d2,8t4,4x3,4d4,4t1,1x2"
+    enc_channel_config: "128:64,64:64,32:128,16:128,8:256,4:512,1:1024"
+    dec_block_config: "1x1,1u4,1t4,4x2,4u2,4t8,8x2,8u2,8t16,16x6,16u2,16t32,32x2,32u2,32t64,64x2,64u2,64t128,128x1"
+    dec_channel_config: "128:64,64:64,32:128,16:128,8:256,4:512,1:1024"
+
+  evaluation:
+    chkpt_path: ???
+    save_path: ???
+    expde_model_path: ""
+    seed: 0
+    device: "gpu:0"
+    workers: 2
+    batch_size: 8
+    n_samples: 50000
+    sample_prefix: ""
+    save_mode: image

--- a/main/configs/dataset/chexpert/train.yaml
+++ b/main/configs/dataset/chexpert/train.yaml
@@ -1,0 +1,75 @@
+# DDPM config used for DDPM training
+ddpm:
+  data:
+    root: ???
+    name: "chexpert"
+    image_size: 224
+    hflip: False
+    n_channels: 1
+    norm: True
+
+  model:
+    dim : 128
+    attn_resolutions: "32,"
+    n_residual: 2
+    dim_mults: "1,2,2,2"
+    dropout: 0.1
+    n_heads: 8
+    beta1: 0.0001
+    beta2: 0.02
+    n_timesteps: 1000
+
+  training:
+    seed: 0
+    fp16: False
+    use_ema: True
+    z_cond: False
+    z_dim: 1024
+    type: 'form1'
+    ema_decay: 0.9999
+    batch_size: 16
+    epochs: 1000
+    log_step: 1
+    device: "gpu:0"
+    chkpt_interval: 1
+    optimizer: "Adam"
+    lr: 2e-4
+    restore_path: ""
+    vae_chkpt_path: ???
+    results_dir: ???
+    workers: 2
+    grad_clip: 1.0
+    n_anneal_steps: 5000
+    loss: "l2"
+    chkpt_prefix: ""
+    cfd_rate: 0.0
+
+vae:
+  data:
+    root: ???
+    name: "chexpert"
+    image_size: 224
+    n_channels: 1
+    hflip: False
+
+  model:
+    enc_block_config : "128x1,128d2,128t64,64x3,64d2,64t32,32x3,32d2,32t16,16x7,16d2,16t8,8x3,8d2,8t4,4x3,4d4,4t1,1x2"
+    enc_channel_config: "128:64,64:64,32:128,16:128,8:256,4:512,1:1024"
+    dec_block_config: "1x1,1u4,1t4,4x2,4u2,4t8,8x2,8u2,8t16,16x6,16u2,16t32,32x2,32u2,32t64,64x2,64u2,64t128,128x1"
+    dec_channel_config: "128:64,64:64,32:128,16:128,8:256,4:512,1:1024"
+
+  training:
+    seed: 0
+    fp16: False
+    batch_size: 16
+    epochs: 1000
+    log_step: 1
+    device: "gpu:0"
+    chkpt_interval: 1
+    optimizer: "Adam"
+    lr: 1e-4
+    restore_path: ""
+    results_dir: ???
+    workers: 2
+    chkpt_prefix: ""
+    alpha: 1.0

--- a/main/datasets/__init__.py
+++ b/main/datasets/__init__.py
@@ -4,3 +4,4 @@ from .cifar10 import CIFAR10Dataset
 from .afhq import AFHQv2Dataset
 from .ffhq import FFHQLmdbDataset, FFHQDataset
 from .celebahq import CelebAHQDataset
+from .chexpert import CheXpertDataset

--- a/main/datasets/chexpert.py
+++ b/main/datasets/chexpert.py
@@ -1,0 +1,39 @@
+import os
+import glob
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+from tqdm import tqdm
+
+
+class CheXpertDataset(Dataset):
+    def __init__(self, root, norm=True, subsample_size=None, transform=None, **kwargs):
+        if not os.path.isdir(root):
+            raise ValueError(f"The specified root: {root} does not exist")
+        self.root = root
+        self.transform = transform
+        self.norm = norm
+
+        self.images = []
+        for ext in ("*.png", "*.jpg", "*.jpeg"):
+            self.images.extend(glob.glob(os.path.join(self.root, "**", ext), recursive=True))
+
+        if subsample_size is not None:
+            self.images = self.images[:subsample_size]
+
+    def __getitem__(self, idx):
+        img_path = self.images[idx]
+        img = Image.open(img_path).convert("L")
+        if self.transform is not None:
+            img = self.transform(img)
+
+        if self.norm:
+            img = (np.asarray(img).astype(np.float32) / 127.5) - 1.0
+        else:
+            img = np.asarray(img).astype(np.float32) / 255.0
+
+        return torch.from_numpy(img).unsqueeze(0).float()
+
+    def __len__(self):
+        return len(self.images)

--- a/main/eval/ddpm/interpolate_ddpm.py
+++ b/main/eval/ddpm/interpolate_ddpm.py
@@ -131,10 +131,10 @@ def interpolate_ddpm(config):
             recons_inter = 2 * recons_inter - 1
 
         x_t1 = config_ddpm.evaluation.temp * torch.randn(
-            1, 3, image_size, image_size, device=dev
+            1, config_ddpm.data.n_channels, image_size, image_size, device=dev
         )
         x_t2 = config_ddpm.evaluation.temp * torch.randn(
-            1, 3, image_size, image_size, device=dev
+            1, config_ddpm.data.n_channels, image_size, image_size, device=dev
         )
 
         if config_ddpm.evaluation.type == "form2":

--- a/main/eval/ddpm/sample.py
+++ b/main/eval/ddpm/sample.py
@@ -89,7 +89,7 @@ def sample(config):
 
     # Create predict dataset of latents
     z_dataset = UncondLatentDataset(
-        (n_samples, 3, image_size, image_size),
+        (n_samples, config.data.n_channels, image_size, image_size),
     )
 
     # Setup devices

--- a/main/eval/ddpm/sample_cond.py
+++ b/main/eval/ddpm/sample_cond.py
@@ -107,7 +107,7 @@ def sample_cond(config):
     # Create predict dataset of latents
     z_dataset = LatentDataset(
         (n_samples, config_vae.model.z_dim, 1, 1),
-        (n_samples, 3, image_size, image_size),
+        (n_samples, config_ddpm.data.n_channels, image_size, image_size),
         share_ddpm_latent=True if ddpm_latent_path != "" else False,
         expde_model_path=config_vae.evaluation.expde_model_path,
         seed=config_ddpm.evaluation.seed,

--- a/main/models/vae.py
+++ b/main/models/vae.py
@@ -103,9 +103,9 @@ class ResBlock(nn.Module):
 
 
 class Encoder(nn.Module):
-    def __init__(self, block_config_str, channel_config_str):
+    def __init__(self, block_config_str, channel_config_str, in_channels=3):
         super().__init__()
-        self.in_conv = nn.Conv2d(3, 64, 3, stride=1, padding=1, bias=False)
+        self.in_conv = nn.Conv2d(in_channels, 64, 3, stride=1, padding=1, bias=False)
 
         block_config = parse_layer_string(block_config_str)
         channel_config = parse_channel_string(channel_config_str)
@@ -144,7 +144,7 @@ class Encoder(nn.Module):
 
 
 class Decoder(nn.Module):
-    def __init__(self, input_res, block_config_str, channel_config_str):
+    def __init__(self, input_res, block_config_str, channel_config_str, out_channels=3):
         super().__init__()
         block_config = parse_layer_string(block_config_str)
         channel_config = parse_channel_string(channel_config_str)
@@ -176,7 +176,9 @@ class Decoder(nn.Module):
             )
         # TODO: If the training is unstable try using scaling the weights
         self.block_mod = nn.Sequential(*blocks)
-        self.last_conv = nn.Conv2d(channel_config[input_res], 3, 3, stride=1, padding=1)
+        self.last_conv = nn.Conv2d(
+            channel_config[input_res], out_channels, 3, stride=1, padding=1
+        )
 
     def forward(self, input):
         x = self.block_mod(input)
@@ -196,6 +198,7 @@ class VAE(pl.LightningModule):
         dec_channel_str,
         alpha=1.0,
         lr=1e-4,
+        n_channels=3,
     ):
         super().__init__()
         self.save_hyperparameters()
@@ -206,12 +209,15 @@ class VAE(pl.LightningModule):
         self.dec_channel_str = dec_channel_str
         self.alpha = alpha
         self.lr = lr
+        self.n_channels = n_channels
 
         # Encoder architecture
-        self.enc = Encoder(self.enc_block_str, self.enc_channel_str)
+        self.enc = Encoder(self.enc_block_str, self.enc_channel_str, in_channels=self.n_channels)
 
         # Decoder Architecture
-        self.dec = Decoder(self.input_res, self.dec_block_str, self.dec_channel_str)
+        self.dec = Decoder(
+            self.input_res, self.dec_block_str, self.dec_channel_str, out_channels=self.n_channels
+        )
 
     def encode(self, x):
         mu, logvar = self.enc(x)

--- a/main/train_ae.py
+++ b/main/train_ae.py
@@ -43,6 +43,7 @@ def train(config):
         dec_channel_str=config.model.dec_channel_config,
         lr=config.training.lr,
         alpha=config.training.alpha,
+        n_channels=config.data.n_channels,
     )
 
     # Trainer

--- a/main/train_ddpm.py
+++ b/main/train_ddpm.py
@@ -86,6 +86,7 @@ def train(config):
     vae = VAE.load_from_checkpoint(
         config.training.vae_chkpt_path,
         input_res=image_size,
+        n_channels=config.data.n_channels,
     )
     vae.eval()
 

--- a/main/util.py
+++ b/main/util.py
@@ -13,6 +13,7 @@ from datasets import (
     CelebAMaskHQDataset,
     CIFAR10Dataset,
     FFHQDataset,
+    CheXpertDataset,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,8 @@ def get_dataset(name, root, image_size, norm=True, flip=False, **kwargs):
         dataset = AFHQv2Dataset(root, norm=norm, transform=transform, **kwargs)
     elif name == "ffhq":
         dataset = FFHQDataset(root, norm=norm, transform=transform, **kwargs)
+    elif name == "chexpert":
+        dataset = CheXpertDataset(root, norm=norm, transform=transform, **kwargs)
     elif name == "cifar10":
         assert image_size == 32
         t_list = []


### PR DESCRIPTION
## Summary
- add a CheXpertDataset loader
- register the new dataset
- create configs for chexpert
- allow VAE to work with arbitrary number of channels
- pass n_channels in training scripts
- adapt evaluation utilities for variable channel count

## Testing
- `python -m py_compile main/models/vae.py main/train_ae.py main/train_ddpm.py main/util.py main/datasets/chexpert.py main/eval/ddpm/sample.py main/eval/ddpm/sample_cond.py main/eval/ddpm/interpolate_ddpm.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68861ab1ad7c832685832d2d2b19451d