### PR TITLE
Add CheXpert downstream classification

### DIFF
--- a/main/datasets/__init__.py
+++ b/main/datasets/__init__.py
@@ -1,7 +1,8 @@
+from .afhq import AFHQv2Dataset
 from .celeba import CelebADataset
 from .celeba_mask import CelebAMaskHQDataset
-from .cifar10 import CIFAR10Dataset
-from .afhq import AFHQv2Dataset
-from .ffhq import FFHQLmdbDataset, FFHQDataset
 from .celebahq import CelebAHQDataset
 from .chexpert import CheXpertDataset
+from .chexpert_labelled import CheXpertLabelledDataset
+from .cifar10 import CIFAR10Dataset
+from .ffhq import FFHQDataset, FFHQLmdbDataset

--- a/main/datasets/chexpert_labelled.py
+++ b/main/datasets/chexpert_labelled.py
@@ -1,0 +1,51 @@
+import os
+
+import numpy as np
+import pandas as pd
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+
+class CheXpertLabelledDataset(Dataset):
+    """CheXpert dataset with multi-label annotations."""
+
+    def __init__(self, csv_path, root, transform=None, norm=True, subsample_size=None):
+        if not os.path.isfile(csv_path):
+            raise ValueError(f"CSV file {csv_path} does not exist")
+        if not os.path.isdir(root):
+            raise ValueError(f"The specified root: {root} does not exist")
+
+        self.root = root
+        self.transform = transform
+        self.norm = norm
+
+        df = pd.read_csv(csv_path)
+        # Assume label columns start after the metadata columns
+        label_cols = df.columns[5:]
+        self.paths = df["Path"].tolist()
+        labels = df[label_cols].fillna(0).replace(-1, 0).astype(np.float32)
+        self.labels = labels.values
+
+        if subsample_size is not None:
+            self.paths = self.paths[:subsample_size]
+            self.labels = self.labels[:subsample_size]
+
+    def __getitem__(self, idx):
+        img_path = os.path.join(self.root, self.paths[idx])
+        img = Image.open(img_path).convert("L")
+        if self.transform is not None:
+            img = self.transform(img)
+
+        img = np.asarray(img).astype(np.float32)
+        if self.norm:
+            img = img / 127.5 - 1.0
+        else:
+            img = img / 255.0
+
+        label = torch.from_numpy(self.labels[idx])
+        img = torch.from_numpy(img).unsqueeze(0).float()
+        return img, label
+
+    def __len__(self):
+        return len(self.paths)

--- a/main/downstream/chexpert_linear_probe.py
+++ b/main/downstream/chexpert_linear_probe.py
@@ -1,0 +1,70 @@
+import os
+from typing import Tuple
+
+import click
+import numpy as np
+import torch
+from datasets import CheXpertLabelledDataset
+from models.vae import VAE
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import f1_score
+from sklearn.model_selection import train_test_split
+from torch.utils.data import DataLoader
+from util import get_dataset
+
+
+@click.command()
+@click.argument("csv-path")
+@click.argument("data-root")
+@click.argument("vae-chkpt")
+@click.option("--batch-size", default=32)
+@click.option("--image-size", default=224)
+@click.option("--test-split", default=0.2)
+@click.option("--device", default="cpu")
+def main(
+    csv_path: str,
+    data_root: str,
+    vae_chkpt: str,
+    batch_size: int,
+    image_size: int,
+    test_split: float,
+    device: str,
+):
+    """Train a simple linear classifier on frozen VAE features."""
+    transform = torch.nn.Identity()
+    dataset = CheXpertLabelledDataset(
+        csv_path, data_root, transform=transform, norm=False
+    )
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=2)
+
+    dev = torch.device(device)
+    vae = VAE.load_from_checkpoint(vae_chkpt, input_res=image_size).to(dev)
+    vae.eval()
+
+    features = []
+    labels = []
+    with torch.no_grad():
+        for imgs, lbls in loader:
+            imgs = imgs.to(dev)
+            mu, logvar = vae.encode(imgs)
+            z = vae.reparameterize(mu, logvar)
+            features.append(z.cpu())
+            labels.append(lbls)
+
+    X = torch.cat(features, dim=0).numpy()
+    y = torch.cat(labels, dim=0).numpy()
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_split, random_state=0
+    )
+
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_test)
+    score = f1_score(y_test, preds, average="micro")
+    print(f"F1 score: {score:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add dataset wrapper with labels for CheXpert
- implement linear probing script for CheXpert using VAE features

## Testing
- `black main/datasets/chexpert_labelled.py main/datasets/__init__.py main/downstream/chexpert_linear_probe.py -q`
- `isort main/datasets/chexpert_labelled.py main/datasets/__init__.py main/downstream/chexpert_linear_probe.py`


------
https://chatgpt.com/codex/tasks/task_b_68863305b1d88326b2b24b9d58547a53